### PR TITLE
feat(config): add easier way to execute code after config has loaded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27807,7 +27807,7 @@
     },
     "packages/angular/config": {
       "name": "@schaman/angular-config",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/packages/angular/config/README.md
+++ b/packages/angular/config/README.md
@@ -133,6 +133,19 @@ import { ConfigService } from '@schaman/angular-config';
 export class AppModule {}
 ```
 
+If you would like to execute code after the config is loaded, you can use the `AFTER_CONFIG_LOAD` provider token just like the `APP_INITIALIZER`.
+Note: `runAsAppInitializer` must be set to `true` for this to work.
+
+```typescript
+providers: [
+  {
+    provide: AFTER_CONFIG_LOAD,
+    useFactory: (store: Store) => () => store.dispatch(loadProfile())
+    deps: [Store],
+  },
+],
+```
+
 ### Configure your generated backend base url
 
 If you generate the backend using [openapi-generator](https://github.com/OpenAPITools/openapi-generator) then provide the values like this:

--- a/packages/angular/config/src/lib/after-config-load.service.spec.ts
+++ b/packages/angular/config/src/lib/after-config-load.service.spec.ts
@@ -1,0 +1,66 @@
+import { TestBed } from '@angular/core/testing';
+import { ConfigService } from './config.service';
+import {
+  provideHttpClientTesting,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { ConfigModuleConfiguration } from './configuration.token';
+import { provideHttpClient } from '@angular/common/http';
+import {
+  AFTER_CONFIG_LOAD,
+  AfterConfigLoadService,
+} from './after-config-load.service';
+import { ConfigModule } from './config.module';
+import { ApplicationInitStatus } from '@angular/core';
+
+describe('AfterConfigLoadService', () => {
+  const setup = (
+    testProviders: any[],
+    configuration?: Partial<ConfigModuleConfiguration>,
+  ) => {
+    const localConfiguration: ConfigModuleConfiguration = {
+      configPath: 'assets/config.json',
+      loadConfig: true,
+      retry: 3,
+      runAsAppInitializer: false,
+      ...configuration,
+    };
+    TestBed.configureTestingModule({
+      imports: [ConfigModule.forRoot(localConfiguration)],
+      providers: [
+        ConfigService,
+        AfterConfigLoadService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        ...testProviders,
+      ],
+    });
+  };
+
+  it('should run provider after config is loaded if runAsAppInitializer is true', async () => {
+    const trackingFn = jest.fn();
+    setup(
+      [
+        {
+          provide: AFTER_CONFIG_LOAD,
+          multi: true,
+          useFactory: () => () => {
+            trackingFn();
+          },
+        },
+      ],
+      {
+        loadConfig: true,
+        runAsAppInitializer: true,
+      },
+    );
+
+    const httpTestingController = TestBed.inject(HttpTestingController);
+    httpTestingController.expectOne('assets/config.json').flush({
+      test: true,
+    });
+    await TestBed.inject(ApplicationInitStatus).donePromise;
+    await TestBed.inject(AfterConfigLoadService).donePromise;
+    expect(trackingFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/angular/config/src/lib/after-config-load.service.ts
+++ b/packages/angular/config/src/lib/after-config-load.service.ts
@@ -1,0 +1,78 @@
+import { Injectable, InjectionToken, inject } from '@angular/core';
+import { Observable, Subscribable } from 'rxjs';
+
+export const AFTER_CONFIG_LOAD = new InjectionToken<
+  ReadonlyArray<() => Observable<unknown> | Promise<unknown> | void>
+>('After config load');
+
+@Injectable()
+export class AfterConfigLoadService {
+  private resolve!: (...args: unknown[]) => void;
+  private reject!: (...args: unknown[]) => void;
+
+  private initialized = false;
+  public readonly done = false;
+  public readonly donePromise: Promise<unknown> = new Promise((res, rej) => {
+    this.resolve = res;
+    this.reject = rej;
+  });
+
+  private readonly afterConfigLoadProviders =
+    inject(AFTER_CONFIG_LOAD, { optional: true }) ?? [];
+
+  constructor() {
+    if (!Array.isArray(this.afterConfigLoadProviders)) {
+      console.error('AFTER_CONFIG_LOAD should be multi provider');
+    }
+  }
+
+  public runAfterConfigLoadProviders(): void {
+    if (this.initialized) {
+      return;
+    }
+
+    const asyncInitPromises = [];
+    for (const appInits of this.afterConfigLoadProviders) {
+      const initResult = appInits();
+      if (this.isPromise(initResult)) {
+        asyncInitPromises.push(initResult);
+      } else if (this.isSubscribable(initResult)) {
+        const observableAsPromise = new Promise<void>((resolve, reject) => {
+          initResult.subscribe({ complete: resolve, error: reject });
+        });
+        asyncInitPromises.push(observableAsPromise);
+      }
+    }
+
+    const complete = () => {
+      // @ts-expect-error overwriting a readonly
+      this.done = true;
+      this.resolve();
+    };
+
+    Promise.all(asyncInitPromises)
+      .then(() => {
+        complete();
+      })
+      .catch((error) => {
+        this.reject(error);
+      });
+
+    if (asyncInitPromises.length === 0) {
+      complete();
+    }
+    this.initialized = true;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private isPromise<T = any>(obj: any): obj is Promise<T> {
+    return !!obj && typeof obj.then === 'function';
+  }
+
+  private isSubscribable<T>(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    obj: any | Subscribable<T>,
+  ): obj is Subscribable<T> {
+    return !!obj && typeof obj.subscribe === 'function';
+  }
+}


### PR DESCRIPTION
The provided way of executing code after the config has been loaded was a bit of a headache if you wanted to use it multiple times, so we decided to create an easier solution.

Angular's APP_INITIALIZER logic was used as the base of the code.
