### PR TITLE
feat(material-error): add generic form error messages

### DIFF
--- a/packages/angular/material-error/package.json
+++ b/packages/angular/material-error/package.json
@@ -6,9 +6,11 @@
     "@angular/common": ">=14.1.0 < 18.0.0",
     "@angular/core": ">=14.1.0 < 18.0.0",
     "@angular/forms": ">=14.1.0 < 18.0.0",
-    "@angular/material": ">=14.1.0 < 18.0.0",
     "@angular/platform-browser": ">=14.1.0 < 18.0.0",
     "rxjs": ">=6.0.0 < 8.0.0"
+  },
+  "optionalDependencies": {
+    "@angular/material": ">=14.1.0 < 18.0.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/angular/material-error/src/lib/dynamic-error.directive.spec.ts
+++ b/packages/angular/material-error/src/lib/dynamic-error.directive.spec.ts
@@ -5,96 +5,312 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { Component, ViewChild } from '@angular/core';
 import {
   FormControl,
+  FormGroup,
+  FormsModule,
   ReactiveFormsModule,
   ValidationErrors,
   Validators,
 } from '@angular/forms';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { fireEvent } from '@testing-library/dom';
 import { ErrorMessageProvider } from './error-message-provider';
 import { DynamicErrorDirective } from './dynamic-error.directive';
 
-@Component({
-  template: `<mat-form-field>
-    <input matInput [formControl]="formControl" />
-    <mat-error *schamanDynamicError></mat-error>
-  </mat-form-field>`,
-  standalone: true,
-  imports: [
-    DynamicErrorDirective,
-    MatInputModule,
-    MatFormFieldModule,
-    ReactiveFormsModule,
-  ],
-})
-class DirectiveTestComponent {
-  @ViewChild(DynamicErrorDirective, { static: true }) directive:
-    | DynamicErrorDirective
-    | undefined;
-  public readonly formControl = new FormControl('', Validators.required);
-}
-
-const render = async () => {
-  await TestBed.configureTestingModule({
-    imports: [DirectiveTestComponent, NoopAnimationsModule],
-    providers: [
-      {
-        provide: ErrorMessageProvider,
-        useValue: {
-          getErrorMessagesFor: (error: ValidationErrors) =>
-            Object.keys(error)[0],
-        },
-      },
-    ],
-  }).compileComponents();
-
-  const fixture = TestBed.createComponent(DirectiveTestComponent);
-  fixture.detectChanges();
-  const loader = TestbedHarnessEnvironment.loader(fixture);
-  return { fixture, loader };
-};
-
 describe('DynamicErrorDirective', () => {
-  it('should create', async () => {
-    const { fixture } = await render();
-    expect(fixture.componentInstance).toBeTruthy();
+  describe('Reactive form with material input', () => {
+    @Component({
+      template: `<form [formGroup]="formGroup">
+        <mat-form-field>
+          <input matInput [formControl]="formControl" />
+          <mat-error *schamanDynamicError></mat-error>
+        </mat-form-field>
+      </form>`,
+      standalone: true,
+      imports: [
+        DynamicErrorDirective,
+        MatInputModule,
+        MatFormFieldModule,
+        ReactiveFormsModule,
+      ],
+    })
+    class DirectiveTestComponent {
+      @ViewChild(DynamicErrorDirective, { static: true }) directive:
+        | DynamicErrorDirective
+        | undefined;
+      public readonly formControl = new FormControl('', Validators.required);
+      public readonly formGroup = new FormGroup({
+        formControl: this.formControl,
+      });
+    }
+
+    const render = async () => {
+      await TestBed.configureTestingModule({
+        imports: [DirectiveTestComponent, NoopAnimationsModule],
+        providers: [
+          {
+            provide: ErrorMessageProvider,
+            useValue: {
+              getErrorMessagesFor: (error: ValidationErrors) =>
+                Object.keys(error)[0],
+            },
+          },
+        ],
+      }).compileComponents();
+
+      const fixture = TestBed.createComponent(DirectiveTestComponent);
+      fixture.detectChanges();
+      const loader = TestbedHarnessEnvironment.loader(fixture);
+      return { fixture, loader };
+    };
+    it('should create', async () => {
+      const { fixture } = await render();
+      expect(fixture.componentInstance).toBeTruthy();
+    });
+
+    it('should show error message', async () => {
+      const { fixture, loader } = await render();
+      const input = await loader.getHarness(MatInputHarness);
+
+      await input.focus();
+      await input.setValue('a');
+      await input.setValue('');
+      await input.blur();
+
+      expect(fixture.nativeElement.textContent).toContain('required');
+    });
+
+    it('should hide error message', async () => {
+      const { fixture, loader } = await render();
+      const input = await loader.getHarness(MatInputHarness);
+
+      await input.focus();
+      await input.setValue('a');
+      await input.setValue('');
+      await input.setValue('a');
+      await input.blur();
+
+      expect(fixture.nativeElement.textContent).not.toContain('required');
+    });
+
+    it('should unsubscribe in on destroy', async () => {
+      const { fixture, loader } = await render();
+      const input = await loader.getHarness(MatInputHarness);
+
+      fixture.componentInstance.directive?.ngOnDestroy();
+      await input.focus();
+      await input.setValue('a');
+      await input.setValue('');
+      await input.blur();
+
+      expect(fixture.nativeElement.textContent).not.toContain('required');
+    });
+
+    it('should show error message on submit', async () => {
+      const { fixture } = await render();
+
+      const form = fixture.nativeElement.querySelector('form');
+      fireEvent.submit(form);
+
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).toContain('required');
+    });
   });
 
-  it('should show error message', async () => {
-    const { fixture, loader } = await render();
-    const input = await loader.getHarness(MatInputHarness);
+  describe('Form with material input', () => {
+    @Component({
+      template: `<form>
+        <mat-form-field>
+          <input matInput [(ngModel)]="value" required name="test" />
+          <mat-error *schamanDynamicError></mat-error>
+        </mat-form-field>
+      </form>`,
+      standalone: true,
+      imports: [
+        DynamicErrorDirective,
+        MatInputModule,
+        MatFormFieldModule,
+        FormsModule,
+      ],
+    })
+    class DirectiveTestComponent {
+      @ViewChild(DynamicErrorDirective, { static: true }) directive:
+        | DynamicErrorDirective
+        | undefined;
+      public value = '';
+    }
 
-    await input.focus();
-    await input.setValue('a');
-    await input.setValue('');
-    await input.blur();
+    const render = async () => {
+      await TestBed.configureTestingModule({
+        imports: [DirectiveTestComponent, NoopAnimationsModule],
+        providers: [
+          {
+            provide: ErrorMessageProvider,
+            useValue: {
+              getErrorMessagesFor: (error: ValidationErrors) =>
+                Object.keys(error)[0],
+            },
+          },
+        ],
+      }).compileComponents();
 
-    expect(fixture.nativeElement.textContent).toContain('required');
+      const fixture = TestBed.createComponent(DirectiveTestComponent);
+      fixture.detectChanges();
+      const loader = TestbedHarnessEnvironment.loader(fixture);
+      return { fixture, loader };
+    };
+    it('should create', async () => {
+      const { fixture } = await render();
+      expect(fixture.componentInstance).toBeTruthy();
+    });
+
+    it('should show error message', async () => {
+      const { fixture, loader } = await render();
+      const input = await loader.getHarness(MatInputHarness);
+
+      await input.focus();
+      await input.setValue('a');
+      await input.setValue('');
+      await input.blur();
+
+      expect(fixture.nativeElement.textContent).toContain('required');
+    });
+
+    it('should hide error message', async () => {
+      const { fixture, loader } = await render();
+      const input = await loader.getHarness(MatInputHarness);
+
+      await input.focus();
+      await input.setValue('a');
+      await input.setValue('');
+      await input.setValue('a');
+      await input.blur();
+
+      expect(fixture.nativeElement.textContent).not.toContain('required');
+    });
+
+    it('should unsubscribe in on destroy', async () => {
+      const { fixture, loader } = await render();
+      const input = await loader.getHarness(MatInputHarness);
+
+      fixture.componentInstance.directive?.ngOnDestroy();
+      await input.focus();
+      await input.setValue('a');
+      await input.setValue('');
+      await input.blur();
+
+      expect(fixture.nativeElement.textContent).not.toContain('required');
+    });
+
+    it('should show error message on submit', async () => {
+      const { fixture } = await render();
+
+      const form = fixture.nativeElement.querySelector('form');
+      fireEvent.submit(form);
+
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).toContain('required');
+    });
   });
 
-  it('should hide error message', async () => {
-    const { fixture, loader } = await render();
-    const input = await loader.getHarness(MatInputHarness);
+  describe('Form control bare', () => {
+    @Component({
+      template: `<form [formGroup]="formGroup">
+        <input [formControl]="formControl" />
+        <div *schamanDynamicError="formControl"></div>
+      </form>`,
+      standalone: true,
+      imports: [DynamicErrorDirective, ReactiveFormsModule],
+    })
+    class DirectiveTestComponent {
+      @ViewChild(DynamicErrorDirective, { static: true }) directive:
+        | DynamicErrorDirective
+        | undefined;
+      public readonly formControl = new FormControl('', Validators.required);
+      public readonly formGroup = new FormGroup({
+        formControl: this.formControl,
+      });
+    }
 
-    await input.focus();
-    await input.setValue('a');
-    await input.setValue('');
-    await input.setValue('a');
-    await input.blur();
+    const render = async () => {
+      await TestBed.configureTestingModule({
+        imports: [DirectiveTestComponent, NoopAnimationsModule],
+        providers: [
+          {
+            provide: ErrorMessageProvider,
+            useValue: {
+              getErrorMessagesFor: (error: ValidationErrors) =>
+                Object.keys(error)[0],
+            },
+          },
+        ],
+      }).compileComponents();
 
-    expect(fixture.nativeElement.textContent).not.toContain('required');
-  });
+      const fixture = TestBed.createComponent(DirectiveTestComponent);
+      fixture.detectChanges();
+      return { fixture };
+    };
+    it('should create', async () => {
+      const { fixture } = await render();
+      expect(fixture.componentInstance).toBeTruthy();
+    });
 
-  it('should unsubscribe in on destroy', async () => {
-    const { fixture, loader } = await render();
-    const input = await loader.getHarness(MatInputHarness);
+    it('should show error message', async () => {
+      const { fixture } = await render();
+      const input = fixture.nativeElement.querySelector('input');
 
-    fixture.componentInstance.directive?.ngOnDestroy();
-    await input.focus();
-    await input.setValue('a');
-    await input.setValue('');
-    await input.blur();
+      fireEvent.focus(input);
+      fireEvent.input(input, { target: { value: 'a' } });
+      fixture.detectChanges();
+      fireEvent.input(input, { target: { value: '' } });
+      fireEvent.blur(input);
+      fixture.detectChanges();
 
-    expect(fixture.nativeElement.textContent).not.toContain('required');
+      expect(fixture.nativeElement.textContent).toContain('required');
+    });
+
+    it('should hide error message', async () => {
+      const { fixture } = await render();
+      const input = fixture.nativeElement.querySelector('input');
+
+      fireEvent.focus(input);
+      fireEvent.input(input, { target: { value: 'a' } });
+      fixture.detectChanges();
+      fireEvent.input(input, { target: { value: '' } });
+      fixture.detectChanges();
+      fireEvent.input(input, { target: { value: 'a' } });
+      fireEvent.blur(input);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).not.toContain('required');
+    });
+
+    it('should unsubscribe in on destroy', async () => {
+      const { fixture } = await render();
+      const input = fixture.nativeElement.querySelector('input');
+
+      fixture.componentInstance.directive?.ngOnDestroy();
+      fireEvent.focus(input);
+      fireEvent.input(input, { target: { value: 'a' } });
+      fixture.detectChanges();
+      fireEvent.input(input, { target: { value: '' } });
+      fireEvent.blur(input);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).not.toContain('required');
+    });
+
+    it('should show error message on submit', async () => {
+      const { fixture } = await render();
+
+      const form = fixture.nativeElement.querySelector('form');
+      fireEvent.submit(form);
+
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).toContain('required');
+    });
   });
 });


### PR DESCRIPTION
Adds support for any non material framework related error messages.